### PR TITLE
FLAC: Fix segfault when setting picture description to ""

### DIFF
--- a/src/flac_tag.c
+++ b/src/flac_tag.c
@@ -1085,7 +1085,10 @@ gboolean Flac_Tag_Write_File_Tag (ET_File *ETFile)
                 FLAC__metadata_object_picture_set_mime_type(picture_block, (gchar *)Picture_Mime_Type_String(format), TRUE);
 
                 // Description
-                FLAC__metadata_object_picture_set_description(picture_block, (FLAC__byte *)pic->description, TRUE);
+                if (pic->description)
+                {
+                    FLAC__metadata_object_picture_set_description(picture_block, (FLAC__byte *)pic->description, TRUE);
+                }
                 
                 // Resolution
                 picture_block->data.picture.width  = pic->width;


### PR DESCRIPTION
This patch has Flac_Tag_Write_File_Tag make sure the picture description string is non-null before attempting to set it.  (Passing a null pointer to FLAC__metadata_object_picture_set_description violates that function's contract; see http://flac.sourceforge.net/api/group\_\_flac\_\_metadata\_\_object.html#ga43).  This brings Flac_Tag_Write_File_Tag's behavior in line with that of the analogous functions for Ogg and ID3 tags.
